### PR TITLE
Add version #s for testing-support libraries

### DIFF
--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -63,9 +63,9 @@ subprojects { project ->
                 runtime "com.h2database:h2"
                 runtime "org.apache.tomcat:tomcat-jdbc"
                 runtime "com.bertramlabs.plugins:asset-pipeline-grails:2.14.2"
-                testCompile "org.grails:grails-gorm-testing-support"
+                testCompile "org.grails:grails-gorm-testing-support:1.1.1"
                 testCompile "org.grails.plugins:geb"
-                testCompile "org.grails:grails-web-testing-support"
+                testCompile "org.grails:grails-web-testing-support:1.1.1"
                 testRuntime "org.seleniumhq.selenium:selenium-htmlunit-driver:2.47.1"
                 testRuntime "net.sourceforge.htmlunit:htmlunit:2.18"
             }
@@ -76,7 +76,7 @@ subprojects { project ->
                 profile "org.grails.profiles:plugin"
                 provided "org.grails:grails-plugin-services"
                 provided "org.grails:grails-plugin-domain-class"
-                testCompile "org.grails:grails-gorm-testing-support"
+                testCompile "org.grails:grails-gorm-testing-support:1.1.1
             }
         }
 


### PR DESCRIPTION
I was following along in the tutorial, and without the version #s on the testing-support libraries, it could not resolve them.