### PR TITLE
Add CI workflow + finalize webapp functional test coverage

### DIFF
--- a/.github/workflows/grails8.yml
+++ b/.github/workflows/grails8.yml
@@ -1,0 +1,45 @@
+name: Grails 8 CI
+
+on:
+  push:
+    branches: [ grails8 ]
+  pull_request:
+    branches: [ grails8 ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    name: complete (test + integrationTest)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      # complete/ is a single Gradle build with three subprojects
+      # (shared-core plugin + webapp-admin + webapp-customer); this runs the
+      # unit (test) and @Integration HTTP (integrationTest) specs for all three.
+      # initial/ is intentionally empty (forge URLs only), so it has no CI job.
+      - name: Unit + integration tests (all modules)
+        working-directory: complete
+        run: |
+          chmod +x gradlew
+          ./gradlew test integrationTest --console=plain --stacktrace
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-reports
+          path: complete/**/build/reports/tests/
+          if-no-files-found: ignore

--- a/complete/webapp-admin/src/integration-test/groovy/admin/AdminBookFunctionalSpec.groovy
+++ b/complete/webapp-admin/src/integration-test/groovy/admin/AdminBookFunctionalSpec.groovy
@@ -79,4 +79,80 @@ class AdminBookFunctionalSpec extends Specification {
         then:
         resp.statusCode() == 422
     }
+
+    void "GET /book/:id shows a single book as JSON"() {
+        given:
+        Book.withNewTransaction {
+            if (!Book.findByIsbn('9780451524935')) {
+                new Book(title: '1984', isbn: '9780451524935', pageCount: 328).save(failOnError: true)
+            }
+        }
+        // Retrieve the id that was assigned
+        Long bookId = Book.withNewTransaction { Book.findByIsbn('9780451524935').id }
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/books/${bookId}.json")).GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+        def json = new JsonSlurper().parseText(resp.body())
+
+        then:
+        resp.statusCode() == 200
+        json.isbn == '9780451524935'
+        json.title == '1984'
+    }
+
+    void "PUT /book/:id updates an existing book"() {
+        given:
+        Book.withNewTransaction {
+            if (!Book.findByIsbn('9780141439518')) {
+                new Book(title: 'Pride', isbn: '9780141439518', pageCount: 280).save(failOnError: true)
+            }
+        }
+        Long bookId = Book.withNewTransaction { Book.findByIsbn('9780141439518').id }
+        String updateBody = JsonOutput.toJson([title: 'Pride and Prejudice', isbn: '9780141439518', pageCount: 432])
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/books/${bookId}"))
+                        .header('Content-Type', 'application/json')
+                        .header('Accept', 'application/json')
+                        .PUT(HttpRequest.BodyPublishers.ofString(updateBody)).build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 200
+        Book.withNewTransaction {
+            Book.findByIsbn('9780141439518').title == 'Pride and Prejudice'
+        }
+    }
+
+    void "DELETE /book/:id removes a book"() {
+        given:
+        Long bookId = Book.withNewTransaction {
+            def b = new Book(title: 'Temp', isbn: '9780000000999', pageCount: 50).save(failOnError: true)
+            b.id
+        }
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri("/books/${bookId}"))
+                        .header('Accept', 'application/json')
+                        .DELETE().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 204
+        Book.withNewTransaction { Book.get(bookId) == null }
+    }
+
+    void "GET /book/:id returns 404 for a nonexistent id"() {
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(uri('/books/99999.json')).GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 404
+    }
 }

--- a/complete/webapp-admin/src/integration-test/groovy/admin/AdminBookFunctionalSpec.groovy
+++ b/complete/webapp-admin/src/integration-test/groovy/admin/AdminBookFunctionalSpec.groovy
@@ -28,7 +28,7 @@ class AdminBookFunctionalSpec extends Specification {
 
     private URI uri(String path) { URI.create("http://localhost:${serverPort}${path}") }
 
-    void "POST /book creates a shared-core Book and returns 201"() {
+    void "POST /books creates a shared-core Book and returns 201"() {
         given:
         String body = JsonOutput.toJson([title: 'Dune', isbn: '9780441013593', pageCount: 412])
 
@@ -45,7 +45,7 @@ class AdminBookFunctionalSpec extends Specification {
         Book.withNewTransaction { Book.findByIsbn('9780441013593')?.title == 'Dune' }
     }
 
-    void "GET /book lists the shared-core Books as JSON"() {
+    void "GET /books lists the shared-core Books as JSON"() {
         given:
         Book.withNewTransaction {
             if (!Book.findByIsbn('9780547928227')) {
@@ -64,7 +64,7 @@ class AdminBookFunctionalSpec extends Specification {
         json*.isbn.contains('9780547928227')
     }
 
-    void "POST /book with a malformed isbn returns 422"() {
+    void "POST /books with a malformed isbn returns 422"() {
         given:
         String body = JsonOutput.toJson([title: 'Bad', isbn: 'not-an-isbn'])
 
@@ -80,7 +80,7 @@ class AdminBookFunctionalSpec extends Specification {
         resp.statusCode() == 422
     }
 
-    void "GET /book/:id shows a single book as JSON"() {
+    void "GET /books/:id shows a single book as JSON"() {
         given:
         Book.withNewTransaction {
             if (!Book.findByIsbn('9780451524935')) {
@@ -102,7 +102,7 @@ class AdminBookFunctionalSpec extends Specification {
         json.title == '1984'
     }
 
-    void "PUT /book/:id updates an existing book"() {
+    void "PUT /books/:id updates an existing book"() {
         given:
         Book.withNewTransaction {
             if (!Book.findByIsbn('9780141439518')) {
@@ -127,7 +127,7 @@ class AdminBookFunctionalSpec extends Specification {
         }
     }
 
-    void "DELETE /book/:id removes a book"() {
+    void "DELETE /books/:id removes a book"() {
         given:
         Long bookId = Book.withNewTransaction {
             def b = new Book(title: 'Temp', isbn: '9780000000999', pageCount: 50).save(failOnError: true)
@@ -146,7 +146,7 @@ class AdminBookFunctionalSpec extends Specification {
         Book.withNewTransaction { Book.get(bookId) == null }
     }
 
-    void "GET /book/:id returns 404 for a nonexistent id"() {
+    void "GET /books/:id returns 404 for a nonexistent id"() {
         when:
         HttpResponse<String> resp = client.send(
                 HttpRequest.newBuilder(uri('/books/99999.json')).GET().build(),

--- a/complete/webapp-customer/src/integration-test/groovy/customer/CatalogFunctionalSpec.groovy
+++ b/complete/webapp-customer/src/integration-test/groovy/customer/CatalogFunctionalSpec.groovy
@@ -48,4 +48,36 @@ class CatalogFunctionalSpec extends Specification {
         json*.isbn.contains('9780547928227')
         json*.isbn.contains('9780441013593')
     }
+
+    void "GET /catalog/show/:id returns a single book as JSON"() {
+        given:
+        Long bookId = Book.withNewTransaction {
+            Book.findByIsbn('9780547928227').id
+        }
+
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(URI.create("http://localhost:${serverPort}/catalog/show/${bookId}.json"))
+                        .header('Accept', 'application/json')
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+        def json = new JsonSlurper().parseText(resp.body())
+
+        then:
+        resp.statusCode() == 200
+        json.title == 'The Hobbit'
+        json.isbn == '9780547928227'
+    }
+
+    void "GET /catalog/show/:id returns 404 for nonexistent book"() {
+        when:
+        HttpResponse<String> resp = client.send(
+                HttpRequest.newBuilder(URI.create("http://localhost:${serverPort}/catalog/show/99999.json"))
+                        .header('Accept', 'application/json')
+                        .GET().build(),
+                HttpResponse.BodyHandlers.ofString())
+
+        then:
+        resp.statusCode() == 404
+    }
 }


### PR DESCRIPTION
## Summary

Adds a Grails 8 CI workflow and finalizes functional test coverage so the
multi-module sample app's `complete/` builds green end to end.

## What runs

`complete/` is a single Gradle build with three subprojects. `./gradlew test integrationTest` is green:

- **shared-core** (the plugin): `BookSpec` (domain constraints) + `BookServiceSpec`.
- **webapp-admin**: `AdminBookFunctionalSpec` - full `Book` CRUD over HTTP (create / list / show / update / delete) plus the 404 and 422 paths, against the shared-core `Book`.
- **webapp-customer**: `CatalogFunctionalSpec` - catalog list / show / 404.

Functional specs are `@Integration` + `java.net.http.HttpClient` (REST over real HTTP) - no browser, no `webdriver-binaries`.

## CI

`.github/workflows/grails8.yml` builds `complete/` (all three modules) on JDK 21 and runs `test integrationTest`. `initial/` is intentionally empty (forge URLs only), so it has no CI job.
